### PR TITLE
Feature/tb 008

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,6 @@
         "@types/cors": "^2.8.18",
         "@types/express": "^5.0.2",
         "@types/jsonwebtoken": "^9.0.9",
-        "@types/node": "^22.15.18",
         "nodemon": "^3.1.10",
         "prisma": "^6.8.2",
         "ts-node": "^10.9.2",
@@ -915,9 +914,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,6 @@
     "@types/cors": "^2.8.18",
     "@types/express": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.9",
-    "@types/node": "^22.15.18",
     "nodemon": "^3.1.10",
     "prisma": "^6.8.2",
     "ts-node": "^10.9.2",
@@ -36,5 +35,8 @@
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.0",
     "zod": "^3.24.4"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,149 @@
+/// <reference types="node" />
+
+import { PrismaClient, ProfessionType } from '../src/generated/prisma'; // PrismaClient y tipos
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log(`Iniciando el script de seed...`);
+
+  // --- 0. Limpiar tablas --- 
+  console.log('Limpiando la tabla Patient...');
+  await prisma.patient.deleteMany({});
+  console.log('Tabla Patient limpiada.');
+
+  console.log('Limpiando la tabla Professional...');
+  await prisma.professional.deleteMany({});
+  console.log('Tabla Professional limpiada.');
+
+  // --- 1. Crear/Asegurar el Profesional "Antonio Jose Barrios Leon" ---
+  const antonioProfessionalData = {
+    id: 1, // ID especificado
+    email: 'antonio@email.com',
+    passwordHash: '$2b$10$4CQ.1AOYRpE5M4IXFaW00.denRK1rym7gqPnpf/5WWpEbiha.ttXm',
+    firstName: 'Antonio Jose', // Nombre interpretado
+    lastName: 'Barrios Leon',  // Apellido interpretado
+    profession: ProfessionType.NUTRITIONIST,
+  };
+
+  let professionalIdToUse: number;
+
+  try {
+    // Paso previo: Verificar si el email 'antonio@email.com' está en uso por OTRO profesional
+    const conflictingProfessional = await prisma.professional.findUnique({
+      where: { email: antonioProfessionalData.email },
+    });
+
+    if (conflictingProfessional && conflictingProfessional.id !== antonioProfessionalData.id) {
+      // El email está en uso por otro profesional. Actualizar el email de ese otro profesional.
+      const newEmailForConflict = `old_${Date.now()}_${conflictingProfessional.email}`;
+      await prisma.professional.update({
+        where: { id: conflictingProfessional.id },
+        data: { email: newEmailForConflict },
+      });
+      console.log(`Email '${antonioProfessionalData.email}' estaba en uso por ID ${conflictingProfessional.id}. Se actualizó a '${newEmailForConflict}'.`);
+    }
+
+    // Ahora proceder con el upsert para el profesional Antonio
+    const professional = await prisma.professional.upsert({
+      where: { id: antonioProfessionalData.id },
+      update: { // Campos a actualizar si el profesional con ID 1 ya existe
+        email: antonioProfessionalData.email,
+        passwordHash: antonioProfessionalData.passwordHash,
+        firstName: antonioProfessionalData.firstName,
+        lastName: antonioProfessionalData.lastName,
+        profession: antonioProfessionalData.profession,
+      },
+      create: antonioProfessionalData, // Datos para crear, incluyendo el ID 1
+    });
+    console.log(`Profesional '${professional.firstName} ${professional.lastName}' (ID: ${professional.id}) procesado (creado/actualizado).`);
+    professionalIdToUse = professional.id;
+  } catch (error) {
+    console.error(`Error al procesar el profesional con ID ${antonioProfessionalData.id}:`, error);
+    console.error('No se pudo crear/actualizar el profesional especificado. Saliendo del seed script.');
+    process.exit(1); // 'process' está disponible gracias a la directiva triple-slash
+  }
+
+  // --- 2. Crear Pacientes (asignados al profesional procesado arriba) ---
+  const patientsData = [
+    {
+      firstName: 'Elena',
+      lastName: 'Gómez',
+      email: 'elena.gomez@example.com',
+      phone: '600111222',
+      birthDate: new Date('1990-05-15'), // Formato YYYY-MM-DD
+      gender: 'Femenino',
+      height: 165,
+      medicalNotes: 'Alergia al polen.',
+      dietRestrictions: 'Ninguna conocida.',
+      objectives: 'Mejorar condición física general.',
+      professionalId: professionalIdToUse,
+    },
+    {
+      firstName: 'Carlos',
+      lastName: 'Ruiz',
+      email: 'carlos.ruiz@example.com',
+      phone: '600333444',
+      birthDate: new Date('1985-11-20'),
+      gender: 'Masculino',
+      height: 180,
+      objectives: 'Aumentar masa muscular.',
+      professionalId: professionalIdToUse,
+    },
+    {
+      firstName: 'Laura',
+      lastName: 'Martínez',
+      email: 'laura.martinez@example.com',
+      phone: '600555666',
+      birthDate: new Date('1995-02-10'),
+      gender: 'Femenino',
+      height: 170,
+      medicalNotes: 'Asma leve, controlada.',
+      dietRestrictions: 'Vegetariana.',
+      objectives: 'Correr una media maratón.',
+      professionalId: professionalIdToUse,
+    },
+    {
+      firstName: 'David',
+      lastName: 'Fernández',
+      email: 'david.fernandez@example.com',
+      // phone: null, // Opcional, se puede omitir
+      birthDate: new Date('1978-09-03'),
+      gender: 'Masculino',
+      height: 175,
+      objectives: 'Perder 5kg de peso.',
+      professionalId: professionalIdToUse,
+    },
+    {
+      firstName: 'Sofía',
+      lastName: 'López',
+      // email: null, // Opcional
+      phone: '600777888',
+      birthDate: new Date('2000-07-25'),
+      gender: 'Femenino',
+      height: 160,
+      dietRestrictions: 'Intolerancia a la lactosa.',
+      objectives: 'Tonificar y mejorar postura.',
+      professionalId: professionalIdToUse,
+    },
+  ];
+
+  console.log(`Creando ${patientsData.length} pacientes...`);
+  for (const patientData of patientsData) {
+    const patient = await prisma.patient.create({
+      data: patientData,
+    });
+    console.log(`  Paciente creado: ${patient.firstName} ${patient.lastName} (ID: ${patient.id})`);
+  }
+
+  console.log('Seed script completado exitosamente.');
+}
+
+main()
+  .catch((e) => {
+    console.error('Error durante la ejecución del seed script:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  }); 

--- a/backend/src/api/controllers/patient.controller.test.ts
+++ b/backend/src/api/controllers/patient.controller.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { listPatients } from './patient.controller'; // Ajusta la ruta si es necesario
+import * as patientService from '../../services/patient.service'; // Para mockear el servicio
+import { AuthenticatedRequest } from '../../middleware/auth.middleware'; // Para tipar req
+import { Response, NextFunction } from 'express';
+import { mockDeep, DeepMockProxy } from 'vitest-mock-extended'; // Para mocks de req/res si se prefiere
+
+// Mockear completamente el módulo patient.service
+vi.mock('../../services/patient.service', () => ({
+  getPatientsForProfessional: vi.fn(), // Mockeamos la función específica que usa listPatients
+}));
+
+// Tipos para los mocks de Express
+// type MockRequest = Partial<AuthenticatedRequest>; // Si usamos mocks parciales manuales
+// type MockResponse = Partial<Response> & { // Si usamos mocks parciales manuales
+//   status: vi.외부Fn<[number], MockResponse>;
+//   json: vi.외부Fn<[any], MockResponse>;
+// }; 
+
+// Usaremos mockDeep para req, res para mayor facilidad y tipado
+type MockRequest = DeepMockProxy<AuthenticatedRequest>;
+type MockResponse = DeepMockProxy<Response>;
+// No necesitamos un tipo MockNextFunction complejo si usamos vi.fn() y dejamos que se infiera o usamos un tipo funcional
+
+describe('PatientController - listPatients', () => {
+  let mockReq: MockRequest;
+  let mockRes: MockResponse;
+  let mockNext: NextFunction; // Tipar como NextFunction, la asignación será un mock
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    
+    mockReq = mockDeep<AuthenticatedRequest>();
+    mockRes = mockDeep<Response>();
+    // Asignar vi.fn() a mockNext. TypeScript debería permitir esto si NextFunction es un tipo de función.
+    // El resultado de vi.fn() es compatible con ser llamado como NextFunction, y tiene propiedades de mock.
+    mockNext = vi.fn() as unknown as NextFunction; // Usar un cast si es necesario para la asignación inicial
+                                                 // pero para las aserciones, lo castearemos de nuevo a un mock. 
+
+    mockRes.status.mockImplementation((statusCode: number) => {
+        mockRes.statusCode = statusCode;
+        return mockRes;
+    });
+  });
+
+  it('should return 200 and a list of patients for a valid professional', async () => {
+    const professionalId = 1;
+    const mockPatientDataFromService: any[] = [
+      {
+        id: 1, firstName: 'Test', lastName: 'User', email: 'test@example.com', professionalId: 1, 
+        phone: null, birthDate: new Date(), gender: null, height: null, 
+        medicalNotes: null, dietRestrictions: null, objectives: null,
+        createdAt: new Date(), updatedAt: new Date()
+      }, 
+      {
+        id: 2, firstName: 'Another', lastName: 'User', email: 'another@example.com', professionalId: 1, 
+        phone: null, birthDate: new Date(), gender: null, height: null, 
+        medicalNotes: null, dietRestrictions: null, objectives: null,
+        createdAt: new Date(), updatedAt: new Date()
+      }
+    ];
+    
+    mockReq.professional = { professionalId: professionalId, email: 'test@pro.com' }; 
+    mockReq.query = {};
+
+    vi.mocked(patientService.getPatientsForProfessional).mockResolvedValue(mockPatientDataFromService);
+
+    await listPatients(mockReq, mockRes, mockNext);
+
+    expect(patientService.getPatientsForProfessional).toHaveBeenCalledWith(professionalId, undefined);
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith(mockPatientDataFromService);
+    // Al hacer la aserción, castear mockNext a un tipo de mock conocido por Vitest/Jest
+    expect(vi.mocked(mockNext)).not.toHaveBeenCalled(); 
+  });
+
+  it('should return 200 and a filtered list when searchQuery is provided', async () => {
+    const professionalId = 1;
+    const searchQuery = 'Test';
+    const mockFilteredPatients: any[] = [
+      {
+        id: 1, firstName: 'Test', lastName: 'User', email: 'test@example.com', professionalId: 1,
+        phone: null, birthDate: new Date(), gender: null, height: null,
+        medicalNotes: null, dietRestrictions: null, objectives: null,
+        createdAt: new Date(), updatedAt: new Date()
+      }
+    ];
+
+    mockReq.professional = { professionalId: professionalId, email: 'test@pro.com' };
+    mockReq.query = { search: searchQuery }; // Añadir searchQuery a req.query
+
+    vi.mocked(patientService.getPatientsForProfessional).mockResolvedValue(mockFilteredPatients);
+
+    await listPatients(mockReq, mockRes, mockNext);
+
+    expect(patientService.getPatientsForProfessional).toHaveBeenCalledWith(professionalId, searchQuery);
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith(mockFilteredPatients);
+    expect(vi.mocked(mockNext)).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 if professional info is not found in token', async () => {
+    // Simular que req.professional no está definido o no tiene professionalId
+    // Opción 1: mockReq.professional = undefined;
+    // Opción 2: mockReq.professional = { email: 'test@pro.com' }; // Sin professionalId
+    mockReq.professional = undefined; 
+    mockReq.query = {};
+
+    // No necesitamos mockear el servicio porque el controlador debería retornar antes
+
+    await listPatients(mockReq, mockRes, mockNext);
+
+    expect(patientService.getPatientsForProfessional).not.toHaveBeenCalled(); // El servicio no debe ser llamado
+    expect(mockRes.status).toHaveBeenCalledWith(403);
+    expect(mockRes.json).toHaveBeenCalledWith({ message: 'Acceso denegado: Información del profesional no encontrada en el token.' });
+    expect(vi.mocked(mockNext)).not.toHaveBeenCalled();
+  });
+
+  it('should call next with error if patientService throws an error', async () => {
+    const professionalId = 1;
+    const errorMessage = 'Database error';
+    const error = new Error(errorMessage);
+
+    mockReq.professional = { professionalId: professionalId, email: 'test@pro.com' };
+    mockReq.query = {};
+
+    // Configurar mock del servicio para que lance un error
+    vi.mocked(patientService.getPatientsForProfessional).mockRejectedValue(error);
+
+    await listPatients(mockReq, mockRes, mockNext);
+
+    expect(patientService.getPatientsForProfessional).toHaveBeenCalledWith(professionalId, undefined);
+    // Verificar que res.status o res.json no fueron llamados directamente por este controlador
+    expect(mockRes.status).not.toHaveBeenCalled();
+    expect(mockRes.json).not.toHaveBeenCalled();
+    // Verificar que next fue llamado con el error
+    expect(vi.mocked(mockNext)).toHaveBeenCalledOnce();
+    expect(vi.mocked(mockNext)).toHaveBeenCalledWith(error);
+  });
+}); 

--- a/backend/src/api/controllers/patient.controller.ts
+++ b/backend/src/api/controllers/patient.controller.ts
@@ -1,0 +1,31 @@
+import { Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../../middleware/auth.middleware'; // Importar para tipar req
+import * as patientService from '../../services/patient.service'; // Importaremos el servicio
+
+// Placeholder para la lógica de listar pacientes
+export const listPatients = async (req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const professionalPayload = req.professional; // Payload del JWT decodificado por el middleware
+
+    if (!professionalPayload || !professionalPayload.professionalId) {
+      // Esto no debería ocurrir si el middleware de autenticación funciona correctamente
+      res.status(403).json({ message: 'Acceso denegado: Información del profesional no encontrada en el token.' });
+      return;
+    }
+
+    const professionalId = professionalPayload.professionalId;
+    const searchQuery = req.query.search as string | undefined;
+
+    const patients = await patientService.getPatientsForProfessional(professionalId, searchQuery);
+    
+    // Por ahora, devolvemos directamente los pacientes del servicio.
+    // Si necesitáramos un mapeo explícito a un PatientResponse DTO diferente al modelo de Prisma,
+    // se haría aquí. Según el análisis anterior, los campos de Prisma Patient son adecuados.
+    res.status(200).json(patients);
+
+  } catch (error) {
+    next(error); // Pasar errores al manejador de errores de Express
+  }
+};
+
+// Aquí se añadirán otras funciones del controlador (getPatientById, createPatient, etc.) 

--- a/backend/src/api/routes/patient.routes.ts
+++ b/backend/src/api/routes/patient.routes.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { listPatients } from '../controllers/patient.controller'; 
+
+// Importaremos el middleware de autenticación aquí cuando esté listo
+// import { authenticateToken } from '../../middleware/auth.middleware'; // La ruta anterior era placeholder
+import { authenticateToken, AuthenticatedRequest } from '../../middleware/auth.middleware'; // Importamos AuthenticatedRequest también si es necesario tipar req en el router
+
+const router = Router();
+
+// Ruta para listar pacientes (GET /api/patients)
+// Se aplicará el middleware de autenticación antes del controlador
+router.get(
+  '/', 
+  authenticateToken, // Aplicamos el middleware de autenticación
+  listPatients 
+);
+
+// Aquí se añadirán otras rutas de pacientes (POST para crear, GET por ID, PUT, DELETE)
+
+export default router; 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,8 @@ import cors from 'cors';
 
 // Importar rutas de autenticación
 import authRoutes from './api/routes/auth.routes';
+// Importar rutas de pacientes
+import patientRoutes from './api/routes/patient.routes';
 
 // Cargar variables de entorno desde .env
 dotenv.config();
@@ -31,6 +33,7 @@ app.get('/', (req: Request, res: Response) => {
 
 // Configurar rutas de la API
 app.use('/api/auth', authRoutes); // Montar rutas de autenticación bajo /api/auth
+app.use('/api/patients', patientRoutes); // Montar rutas de pacientes bajo /api/patients
 
 // Iniciar el servidor
 app.listen(PORT, () => {

--- a/backend/src/config/db/__mocks__/prisma.client.ts
+++ b/backend/src/config/db/__mocks__/prisma.client.ts
@@ -1,0 +1,8 @@
+import { mockDeep, DeepMockProxy } from 'vitest-mock-extended';
+import { PrismaClient } from '../../../generated/prisma'; // Ruta relativa desde __mocks__ a generated/prisma
+
+// Creamos y exportamos la instancia mockeada del cliente Prisma.
+// Vitest la usará automáticamente cuando se importe '../config/db/prisma.client' en los tests.
+const prismaMockInstance = mockDeep<PrismaClient>();
+
+export default prismaMockInstance; 

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -1,0 +1,46 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+// Extendemos la interfaz Request de Express para incluir la propiedad 'professional'
+export interface AuthenticatedRequest extends Request {
+  professional?: any; // Podríamos definir una interfaz más estricta para el payload del token
+}
+
+export const authenticateToken = (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1]; // Formato "Bearer TOKEN"
+
+  if (token == null) {
+    res.status(401).json({ message: 'Acceso no autorizado: Token no proporcionado.' });
+    return;
+  }
+
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) {
+    console.error('JWT_SECRET no está definida en las variables de entorno.');
+    res.status(500).json({ message: 'Error interno del servidor: Configuración de JWT ausente.' });
+    return;
+  }
+
+  jwt.verify(token, jwtSecret, (err: any, decodedPayload: any) => {
+    if (err) {
+      if (err.name === 'TokenExpiredError') {
+        res.status(401).json({ message: 'Acceso no autorizado: Token expirado.' });
+        return;
+      }
+      if (err.name === 'JsonWebTokenError') {
+        res.status(403).json({ message: 'Acceso no autorizado: Token inválido.' });
+        return;
+      }
+      // Para otros errores inesperados durante la verificación del token
+      console.error('Error al verificar el token JWT:', err);
+      res.status(403).json({ message: 'Acceso no autorizado: Error al verificar el token.' });
+      return;
+    }
+
+    // Si el token es válido, adjuntamos el payload decodificado al objeto request
+    // El payload debería contener la información del profesional (ej. professionalId, email)
+    req.professional = decodedPayload;
+    next(); // Pasar al siguiente middleware o controlador
+  });
+}; 

--- a/backend/src/services/patient.service.test.ts
+++ b/backend/src/services/patient.service.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+// Importa el cliente Prisma TAL COMO LO HACE EL SERVICIO. 
+// Vitest debería reemplazar esto con el contenido de __mocks__/prisma.client.ts
+import prismaFromServicePerspective from '../config/db/prisma.client'; 
+import { getPatientsForProfessional } from './patient.service';
+import { type Patient } from '../generated/prisma';
+import { type DeepMockProxy } from 'vitest-mock-extended'; // Solo necesitamos el tipo aquí
+import { type PrismaClient } from '../generated/prisma'; // Solo el tipo
+
+// Esta será nuestra referencia al mock, que debería ser la misma instancia que prismaFromServicePerspective
+const prismaClientMock = prismaFromServicePerspective as DeepMockProxy<PrismaClient>; 
+
+describe('PatientService - getPatientsForProfessional', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Si necesitas resetear específicamente el mock, ya tienes la referencia correcta:
+    // prismaClientMock.patient.findMany.mockClear(); 
+  });
+
+  it('should return a list of patients for a valid professionalId', async () => {
+    const professionalId = 1;
+    const mockPatientsData: Patient[] = [
+      {
+        id: 101,
+        professionalId: professionalId,
+        firstName: 'Test',
+        lastName: 'PatientA',
+        email: 'test.patient.a@example.com',
+        phone: '123456789',
+        birthDate: new Date('1990-01-01'),
+        gender: 'Masculino',
+        height: 175,
+        medicalNotes: 'None',
+        dietRestrictions: 'None',
+        objectives: 'Get fit',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 102,
+        professionalId: professionalId,
+        firstName: 'Another',
+        lastName: 'PatientB',
+        email: 'another.patient.b@example.com',
+        phone: '987654321',
+        birthDate: new Date('1992-02-02'),
+        gender: 'Femenino',
+        height: 165,
+        medicalNotes: 'Allergy to nuts',
+        dietRestrictions: 'No nuts',
+        objectives: 'Lose weight',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    // Configurar el mock. Ahora estamos seguros de que es la misma instancia que usa el servicio.
+    prismaClientMock.patient.findMany.mockResolvedValue(mockPatientsData);
+
+    const result = await getPatientsForProfessional(professionalId);
+
+    expect(result).toEqual(mockPatientsData);
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledOnce();
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledWith({
+      where: { professionalId: professionalId },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('should return a filtered list of patients when searchQuery matches a name', async () => {
+    const professionalId = 1;
+    const searchQuery = 'Test'; // Suponiendo que buscamos pacientes con firstName 'Test'
+    
+    // Paciente que esperamos encontrar
+    const expectedPatient: Patient = {
+      id: 101,
+      professionalId: professionalId,
+      firstName: 'Test',
+      lastName: 'PatientA',
+      email: 'test.patient.a@example.com',
+      phone: '123456789',
+      birthDate: new Date('1990-01-01'),
+      gender: 'Masculino',
+      height: 175,
+      medicalNotes: 'None',
+      dietRestrictions: 'None',
+      objectives: 'Get fit',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    // Mock de Prisma devuelve solo el paciente que coincide
+    prismaClientMock.patient.findMany.mockResolvedValue([expectedPatient]);
+
+    const result = await getPatientsForProfessional(professionalId, searchQuery);
+
+    expect(result).toEqual([expectedPatient]);
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledOnce();
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledWith({
+      where: {
+        professionalId: professionalId,
+        OR: [
+          { firstName: { contains: searchQuery, mode: 'insensitive' } },
+          { lastName: { contains: searchQuery, mode: 'insensitive' } },
+          { email: { contains: searchQuery, mode: 'insensitive' } },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('should return a filtered list of patients when searchQuery matches an email', async () => {
+    const professionalId = 1;
+    const searchQuery = 'test.patient.a@example.com';
+    
+    const expectedPatient: Patient = {
+      id: 101,
+      professionalId: professionalId,
+      firstName: 'Test',
+      lastName: 'PatientA',
+      email: 'test.patient.a@example.com',
+      phone: '123456789',
+      birthDate: new Date('1990-01-01'),
+      gender: 'Masculino',
+      height: 175,
+      medicalNotes: 'None',
+      dietRestrictions: 'None',
+      objectives: 'Get fit',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    prismaClientMock.patient.findMany.mockResolvedValue([expectedPatient]);
+
+    const result = await getPatientsForProfessional(professionalId, searchQuery);
+
+    expect(result).toEqual([expectedPatient]);
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledOnce();
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledWith({
+      where: {
+        professionalId: professionalId,
+        OR: [
+          { firstName: { contains: searchQuery, mode: 'insensitive' } },
+          { lastName: { contains: searchQuery, mode: 'insensitive' } },
+          { email: { contains: searchQuery, mode: 'insensitive' } },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('should return an empty array if the professionalId has no patients', async () => {
+    const professionalId = 99; // Un ID que asumimos no tiene pacientes
+    const mockPatientsData: Patient[] = []; // Esperamos un array vacío
+
+    prismaClientMock.patient.findMany.mockResolvedValue(mockPatientsData);
+
+    const result = await getPatientsForProfessional(professionalId);
+
+    expect(result).toEqual([]);
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledOnce();
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledWith({
+      where: { professionalId: professionalId }, // Sin cláusula OR porque no hay searchQuery
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('should return an empty array if searchQuery finds no matches', async () => {
+    const professionalId = 1;
+    const searchQuery = 'NonExistentNameOrEmail';
+    const mockPatientsData: Patient[] = []; // Esperamos un array vacío
+
+    prismaClientMock.patient.findMany.mockResolvedValue(mockPatientsData);
+
+    const result = await getPatientsForProfessional(professionalId, searchQuery);
+
+    expect(result).toEqual([]);
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledOnce();
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledWith({
+      where: {
+        professionalId: professionalId,
+        OR: [
+          { firstName: { contains: searchQuery, mode: 'insensitive' } },
+          { lastName: { contains: searchQuery, mode: 'insensitive' } },
+          { email: { contains: searchQuery, mode: 'insensitive' } },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('should throw an error if Prisma client throws an error', async () => {
+    const professionalId = 1;
+    const errorMessage = 'Database connection lost';
+
+    // Configurar el mock para que lance un error
+    prismaClientMock.patient.findMany.mockRejectedValue(new Error(errorMessage));
+
+    // Verificar que la función lanza un error
+    // Usamos expect(...).rejects.toThrowError() para funciones asíncronas
+    await expect(getPatientsForProfessional(professionalId)).rejects.toThrowError(errorMessage);
+    
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledOnce();
+    expect(prismaClientMock.patient.findMany).toHaveBeenCalledWith({
+      where: { professionalId: professionalId },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+}); 

--- a/backend/src/services/patient.service.ts
+++ b/backend/src/services/patient.service.ts
@@ -1,0 +1,48 @@
+import prisma from '../config/db/prisma.client'; // Importar cliente Prisma
+import { Patient } from '../generated/prisma'; // Importar el tipo Patient generado
+
+/**
+ * Obtiene los pacientes para un profesional específico, con opción de búsqueda.
+ * @param professionalId El ID del profesional.
+ * @param searchQuery Término de búsqueda opcional para filtrar por nombre, apellido o email.
+ * @returns Una promesa que resuelve a un array de pacientes.
+ */
+export const getPatientsForProfessional = async (
+  professionalId: number, // Asumiendo que professionalId es numérico según el schema
+  searchQuery?: string
+): Promise<Patient[]> => {
+  try {
+    const whereClause: any = {
+      professionalId: professionalId,
+      // Como no hay soft delete en el schema actual, no filtramos por is_deleted
+    };
+
+    if (searchQuery && searchQuery.trim() !== '') {
+      const searchCondition = {
+        contains: searchQuery.trim(),
+        mode: 'insensitive', // Búsqueda case-insensitive
+      };
+      whereClause.OR = [
+        { firstName: searchCondition },
+        { lastName: searchCondition },
+        { email: searchCondition }, // email es String? en el schema, Prisma maneja esto bien
+      ];
+    }
+
+    const patients = await prisma.patient.findMany({
+      where: whereClause,
+      orderBy: {
+        createdAt: 'desc', // Orden por defecto: más recientes primero
+      },
+      // Aquí podríamos añadir `include` o `select` si queremos dar forma a la respuesta
+      // de manera diferente al modelo Patient completo, pero por ahora devolvemos el modelo completo.
+    });
+
+    return patients;
+  } catch (error) {
+    // Podríamos tener un logger más sofisticado aquí
+    console.error(`Error en getPatientsForProfessional: ${error}`);
+    // Relanzar el error para que el controlador lo maneje y envíe una respuesta HTTP adecuada
+    throw error; 
+  }
+}; 

--- a/docs/api/openapi_spec.yaml
+++ b/docs/api/openapi_spec.yaml
@@ -11,7 +11,7 @@ info:
     email: soporte@example.com # Reemplazar con email real si aplica
 
 servers:
-  - url: http://localhost:3010/api # Asumiendo backend en puerto 3010
+  - url: http://localhost:3000/api # Puerto por defecto es 3000
     description: Servidor de desarrollo local
   - url: https://api.nutritrackpro.com/api # URL de producción (ejemplo)
     description: Servidor de producción

--- a/prompts.md
+++ b/prompts.md
@@ -178,6 +178,60 @@ Necesito refinar y simplificar ciertos puntos del MVP para lograr tener algo fun
 **Prompt 16 (Relacionado con TB-004 - Frontend - Cierre de Sesión - Corrección Estilos/Fondos):**
 "Las paginas de login y registro entre otras, presentar un espacio en blanco que se nota respecto al fondo gris. Puedes eliminarlo y hacer lo mismo para todas?"
 
+**Prompt 17 (Relacionado con TB-008 - Backend - Plan de Acción Inicial):**
+"Plantea un plan de accion para el desarrollo del ticket "TB-008" de @tickets_backend.md"
+
+**Prompt 18 (Relacionado con TB-008 - Backend - Corrección Estructura de Carpetas):**
+"Hay cosas que no estan bien. Tienes que respectar la estructura de carpetas existente. Por ejemplo dentro de src/api existen las carpetas "routes" para las rutas como "auth.routes.ts" y la carpeta "controllers" donde esta el controlador de auth.controller. Haz lo mismo para estos archivos que has generado de patients."
+
+**Prompt 19 (Relacionado con TB-008 - Backend - Middleware de Autenticación y Lógica Controlador/Servicio Inicial):**
+Contexto: Este prompt agrupa la creación inicial del middleware de autenticación, la actualización del controlador `listPatients` para usar `professionalId` y llamar al servicio, y la creación inicial de `patient.service.ts` con la lógica de `getPatientsForProfessional`. (La conversación original fue paso a paso, aquí se resume la intención del bloque de trabajo)
+"Continuemos con el Paso 3: Desarrollo de la Lógica en Controlador y Servicio, comenzando por el middleware de autenticación y luego el servicio y controlador de pacientes."
+
+**Prompt 20 (Relacionado con TB-008 - Backend - Debug Puerto y Generación cURL):**
+Contexto: Se detectó que el puerto de la API era 3000 y no 8000. Se solicitó actualizar la documentación y los cURL.
+"La api corre en el puerto 3000. Recuerdalo. Puedes actualizar la documentacion donde esta mal y asi no lo induzcas mal para la proxima vez? Ahora vuelve a generarme los curls anteriores con esta modificacion del puerto. Tambien puedes crearme un curl para autenticarme y coger el token?"
+
+**Prompt 21 (Relacionado con TB-008 - Backend - Debug Token Expirado/Inválido - Error 401):**
+Contexto: El usuario obtenía un 401 al listar pacientes. Se investigó el token y la configuración de expiración.
+"He lanzado el curl de listar pacientes y me devuelve un 401 no autorizado. ¿Puedes ayudarme? Token: [TOKEN_PROPORCIONADO_POR_USUARIO]" y posterior "Ya funciona. La variable en .env estaba mal seteada, tenia "1h" en lugar de 3600"
+
+**Prompt 22 (Relacionado con TB-008 - Backend - Creación y Refinamiento Script Seed Prisma):**
+Contexto: Creación inicial del script de seed, corrección de errores de linter (`process` no definido, importación de PrismaClient), adición de un profesional específico, manejo de conflictos de email único, y modificación para borrar datos antes de la creación.
+"Lee el esquema de la base de datos y dame una forma de popular la tabla "patients" con unos 5." (Siguieron múltiples prompts de corrección y adición resumidos aquí)
+  - "El fichero @seed.ts tienes errores (referente a `process` no definido)"
+  - "Añade al script de seed, crear un profesional con estos datos: 1, antonio@email.com, $2b$10$4CQ.1AOYRpE5M4IXFaW00.denRK1rym7gqPnpf/5WWpEbiha.ttXm, Antonio Jose Barrios Leon, NUTRITIONIST"
+  - "He lanzado el seed y en el terminal @zsh me da error (referente a `Unique constraint failed on the fields: (\`email\`)`)"
+  - "Quiero que el script borre a todos los profesionales y cree solo a antonioProfessionalData. Lo mismo para los pacientes, borrarlos todos y crear los 5 de ejemplo."
+
+**Prompt 23 (Relacionado con TB-008 - Backend - Debug Listar Pacientes Devuelve `[]`):**
+Contexto: Tras ejecutar el seed, el endpoint devolvía un array vacío. Se verificó el flujo del `professionalId` desde el token.
+"Al listar pacientes, el endpoint me devuelve []" y posterior confirmación "Ya esta he hecho login de nuevo y funciona"
+
+**Prompt 24 (Relacionado con TB-008 - Backend - Inicio Pruebas Unitarias Servicio `patient.service.ts`):**
+"Vamos a realizar las pruebas unitarias (para `patient.service.ts`)"
+
+**Prompt 25 (Relacionado con TB-008 - Backend - Corrección Mocks Prisma en Tests Servicio):**
+Contexto: Múltiples iteraciones para corregir el mock de Prisma en `patient.service.test.ts`, lidiando con errores de inicialización (`Cannot access 'prismaMock' before initialization`) y la correcta aplicación del mock automático de Vitest (`__mocks__` directory) y la posterior corrección de la aserción (`expected undefined to deeply equal ...`).
+  - "Hay un test que falla en @node (referente a `Cannot access 'prismaMock' before initialization`)"
+  - "Sigue fallando @node (referente a `Cannot access '__vi_import_0__' before initialization`)"
+  - "Sigue fallando, echa un vistazo a @node (referente a `Cannot access 'mockPrismaInstance' before initialization`)"
+  - "Ha fallado un test en @node (referente a `AssertionError: expected undefined to deeply equal ...`)"
+
+**Prompt 26 (Relacionado con TB-008 - Backend - Implementación Casos de Prueba Servicio `patient.service.ts`):**
+"Ya pasa, fantastico!. Continuemos con el resto de unit tests (para `patient.service.ts`)"
+
+**Prompt 27 (Relacionado con TB-008 - Backend - Inicio Pruebas Controlador `patient.controller.ts`):**
+"Pasemos a las pruebas del controlador"
+
+**Prompt 28 (Relacionado con TB-008 - Backend - Corrección Mocks/Tipos en Tests Controlador):**
+Contexto: Corrección de errores de linter y tipado en `patient.controller.test.ts` al configurar mocks para `req`, `res`, `next` y la función de servicio mockeada, específicamente el uso de `vi.mocked` y el tipado de los datos devueltos por el servicio mockeado.
+  - "For the code present, we get this error: La propiedad 'mockResolvedValue' no existe en el tipo..."
+  - "Los test fallan, echa un vistazo a @node (referente a `TypeError: ... is not a spy or a call to a spy!` para `mockNext`)"
+
+**Prompt 29 (Relacionado con TB-008 - Backend - Implementación Casos de Prueba Controlador `patient.controller.ts`):**
+"Continua construyendo tests para el controlador por favor"
+
 ---
 
 ### 7. Pull Requests


### PR DESCRIPTION
## Resumen de Cambios para el Ticket TB-008: Listar/Buscar Pacientes

Esta Pull Request introduce la funcionalidad de backend para listar y buscar pacientes asociados a un profesional autenticado, correspondiente al ticket `TB-008`.

**Funcionalidades Implementadas:**

*   **Endpoint API:**
    *   Se ha añadido el endpoint `GET /api/patients`.
    *   Permite listar todos los pacientes asociados al `professionalId` obtenido del token JWT.
    *   Soporta un query parameter opcional `search` para filtrar pacientes por `firstName`, `lastName`, o `email` (búsqueda case-insensitive).
*   **Estructura de Código:**
    *   Se han creado los archivos necesarios siguiendo la estructura modular del proyecto:
        *   `backend/src/api/routes/patient.routes.ts`: Define la ruta del endpoint.
        *   `backend/src/api/controllers/patient.controller.ts`: Contiene la lógica del controlador (`listPatients`) para manejar la solicitud, llamar al servicio y enviar la respuesta.
        *   `backend/src/services/patient.service.ts`: Implementa la lógica de negocio (`getPatientsForProfessional`) para interactuar con la base de datos (Prisma) y aplicar el filtrado.
    *   Se ha integrado la nueva ruta de pacientes en `backend/src/app.ts`.
*   **Autenticación:**
    *   Se ha creado y aplicado el middleware `backend/src/middleware/auth.middleware.ts` a la ruta de pacientes para asegurar que solo los profesionales autenticados puedan acceder.
    *   El middleware extrae el `professionalId` del payload del token JWT.
*   **Script de Seed:**
    *   Se ha mejorado el script `backend/prisma/seed.ts`:
        *   Ahora limpia las tablas `Professional` y `Patient` antes de ejecutarse.
        *   Crea un profesional específico ("Antonio Jose Barrios Leon" con ID 1) para pruebas.
        *   Crea 5 pacientes de ejemplo asociados a este profesional.
        *   Incluye manejo de conflictos de email para el profesional de prueba.
*   **Pruebas Unitarias (Vitest):**
    *   **Servicio (`patient.service.test.ts`):**
        *   Pruebas exhaustivas para `getPatientsForProfessional`, cubriendo:
            *   Listado exitoso.
            *   Búsqueda por nombre y email.
            *   Casos donde no se encuentran pacientes (array vacío).
            *   Manejo de errores de Prisma.
        *   Se ha implementado el mock de `PrismaClient` usando el directorio `__mocks__` para un testing aislado y fiable.
    *   **Controlador (`patient.controller.test.ts`):**
        *   Pruebas para la función `listPatients`, verificando:
            *   Respuestas HTTP correctas (200 OK, 403 Forbidden).
            *   Llamadas correctas al servicio con y sin `searchQuery`.
            *   Manejo de errores del servicio (propagación a `next()`).
        *   Mocks para `Request`, `Response`, `NextFunction` de Express y el `patientService`.
*   **Documentación:**
    *   Se ha actualizado `docs/api/openapi_spec.yaml` para reflejar el puerto correcto de la API (3000).
    *   Se ha actualizado `prompts.md` con los prompts utilizados durante el desarrollo de esta funcionalidad.

**Consideraciones Adicionales:**

*   Se ha asegurado la correcta configuración de variables de entorno para JWT (`JWT_SECRET`, `JWT_EXPIRES_IN`).
*   Se ha depurado y resuelto un problema inicial donde el listado de pacientes devolvía un array vacío debido a un token JWT incorrecto/antiguo.

**Cómo Probar Manualmente:**

1.  Asegurar que el backend esté corriendo (`npm run dev` o similar).
2.  Ejecutar el script de seed: `npm run db:seed`.
3.  Obtener un token JWT haciendo login como `antonio@email.com` (endpoint `POST /api/auth/login`).
4.  Realizar una petición `GET /api/patients` con el token en el header `Authorization: Bearer <token>`.
    *   Para buscar: `GET /api/patients?search=nombre_o_email`

Esta implementación cumple con los requisitos del ticket `TB-008` y establece una base sólida para futuras interacciones con la entidad `Patient`.