### PR TITLE
feature/TB-014a

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -118,6 +118,8 @@ model DietPlan {
   objectives     String?   @db.Text
   isActive       Boolean   @default(true)
   notes          String?   @db.Text
+  isDeleted      Boolean   @default(false)
+  deletedAt      DateTime?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
@@ -128,8 +130,10 @@ model DietPlan {
   @@index([professionalId])
   @@index([patientId])
   @@index([isActive])
+  @@index([isDeleted])
   @@index([startDate, endDate])
   @@index([patientId, isActive])
+  @@index([patientId, isDeleted])
 }
 
 model DietMeal {

--- a/backend/src/api/controllers/diet.controller.ts
+++ b/backend/src/api/controllers/diet.controller.ts
@@ -149,4 +149,51 @@ export const updateDietPlan = async (
     res.status(500).json({ message: 'Error interno del servidor.' });
     return;
   }
+};
+
+// Nueva función para eliminar un plan de dieta (soft delete)
+export const deleteDietPlan = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const dietPlanId = parseInt(req.params.dietPlanId, 10);
+    const professionalId = req.professional?.professionalId;
+
+    // Verificar si professionalId existe
+    if (!professionalId) {
+      res.status(401).json({ message: 'Profesional no autenticado o token inválido.' });
+      return;
+    }
+
+    // Validar que dietPlanId sea un número válido
+    if (isNaN(dietPlanId) || dietPlanId <= 0) {
+      res.status(400).json({ message: 'ID del plan de dieta inválido.' });
+      return;
+    }
+
+    // Eliminar el plan de dieta (soft delete)
+    await dietService.deleteDietPlan(dietPlanId, professionalId);
+
+    // Responder con éxito (204 No Content es apropiado para eliminaciones exitosas)
+    res.status(204).send();
+  } catch (error) {
+    // Manejar errores específicos
+    if (error instanceof Error) {
+      if (error.message.includes('Plan de dieta no encontrado')) {
+        res.status(404).json({ message: 'Plan de dieta no encontrado.' });
+        return;
+      }
+      
+      if (error.message.includes('Acceso no autorizado')) {
+        res.status(403).json({ message: 'No tienes permisos para eliminar este plan de dieta.' });
+        return;
+      }
+    }
+
+    console.error('Error eliminando plan de dieta:', error);
+    res.status(500).json({ message: 'Error interno del servidor.' });
+    return;
+  }
 }; 

--- a/backend/src/api/routes/diet.routes.ts
+++ b/backend/src/api/routes/diet.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createDietPlanForPatient, getDietPlanById, updateDietPlan } from '../controllers/diet.controller';
+import { createDietPlanForPatient, getDietPlanById, updateDietPlan, deleteDietPlan } from '../controllers/diet.controller';
 import { authenticateToken } from '../../middleware/auth.middleware';
 
 const router = Router();
@@ -12,5 +12,8 @@ router.route('/:dietPlanId').get(authenticateToken, getDietPlanById);
 
 // Nueva ruta para actualizar un plan de dieta específico por ID
 router.route('/:dietPlanId').put(authenticateToken, updateDietPlan);
+
+// Nueva ruta para eliminar un plan de dieta específico por ID (soft delete)
+router.route('/:dietPlanId').delete(authenticateToken, deleteDietPlan);
 
 export default router; 


### PR DESCRIPTION
# Resumen de Cambios - Ticket TB-014A: Eliminación de Plan de Dieta (Soft Delete)

## 📋 Descripción

Implementación completa de la funcionalidad de eliminación de planes de dieta utilizando soft delete, permitiendo que los profesionales eliminen sus planes de manera segura sin pérdida permanente de datos.

## 🔧 Cambios Realizados

### **Base de Datos**
- **Esquema Prisma**: Añadidos campos `isDeleted` (Boolean, default: false) y `deletedAt` (DateTime opcional) al modelo `DietPlan`
- **Migración**: Creada migración `20250608102510_add_soft_delete_to_diet_plan` con índices optimizados
- **Índices**: Añadidos índices en `isDeleted` y `(patientId, isDeleted)` para consultas eficientes

### **Backend - Servicio**
- **Nueva función**: `deleteDietPlan()` implementada con soft delete seguro
- **Autorización**: Verificación de propiedad del plan (solo el profesional propietario puede eliminar)
- **Filtrado**: Actualizadas funciones `getDietPlanById()` y `updateDietPlan()` para excluir planes eliminados
- **Consistencia**: Todos los métodos ahora respetan el estado `isDeleted: false`

### **Backend - Controlador y Rutas**
- **Controlador**: Función `deleteDietPlan()` con manejo completo de errores HTTP
- **Ruta**: `DELETE /api/diets/:dietPlanId` protegida con autenticación JWT
- **Respuestas**: Códigos HTTP apropiados (204, 401, 403, 404, 500)
- **Validación**: Verificación de parámetros y autorización de usuario

### **Testing**
- **Tests Nuevos**: 7 tests unitarios completos para `deleteDietPlan()`
  - Eliminación exitosa (soft delete)
  - Plan no encontrado
  - Plan ya eliminado
  - Sin autorización
  - Errores de base de datos
  - Verificación de timestamp `deletedAt`
- **Tests Actualizados**: Corregidos 4 tests existentes de `getDietPlanById()` para incluir filtro `isDeleted: false`
- **Cobertura**: 39/39 tests pasando ✅

## 🚀 Funcionalidades Implementadas

### **Soft Delete Seguro**
- Los planes se marcan como eliminados sin pérdida de datos
- Timestamp `deletedAt` para auditoría y trazabilidad
- Planes eliminados no aparecen en consultas normales

### **Autorización Robusta**
- Solo el profesional propietario puede eliminar sus planes
- Verificación a nivel de base de datos mediante relación `patient.professionalId`
- Manejo de errores de autorización con respuestas HTTP apropiadas

### **Consistencia del Sistema**
- Filtrado automático de planes eliminados en todas las operaciones
- Integridad referencial mantenida
- No afecta comidas asociadas (se mantienen para auditoría)

## 📊 Estadísticas de Cambios

- **Archivos Modificados**: 4
- **Líneas Añadidas**: ~180
- **Tests Nuevos**: 7
- **Tests Actualizados**: 4
- **Migración BD**: 1

## 🧪 Validación

- ✅ Compilación TypeScript sin errores
- ✅ Todos los tests unitarios pasando (39/39)
- ✅ Migración de base de datos aplicada exitosamente
- ✅ Funcionalidad probada con casos de éxito y error

## 🔗 Endpoint Implementado

```http
DELETE /api/diets/:dietPlanId
Authorization: Bearer <JWT_TOKEN>

Responses:
- 204 No Content: Eliminación exitosa
- 401 Unauthorized: Token inválido
- 403 Forbidden: Sin permisos
- 404 Not Found: Plan no encontrado
- 500 Internal Server Error: Error del servidor
```

## 📝 Archivos Afectados

- `backend/prisma/schema.prisma` - Modelo DietPlan actualizado
- `backend/src/services/diet.service.ts` - Lógica de soft delete
- `backend/src/api/controllers/diet.controller.ts` - Controlador de eliminación
- `backend/src/api/routes/diet.routes.ts` - Nueva ruta DELETE
- `backend/tests/unit/services/diet.service.test.ts` - Tests unitarios

---

**Relacionado con**: TB-014A - Eliminación de Plan de Dieta  
**Tipo**: Feature  
**Prioridad**: Media  
**Estado**: ✅ Completado